### PR TITLE
Prevent PTable from interfering with prettytable.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.7.2" %}
 {% set hash_type = "sha256" %}
 {% set hash = "2d5460dc9db74a32bcc8f9f67de68b2c4f4d2f01fa3bd518764c69156d9cacd9" %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 
 package:
@@ -28,6 +28,8 @@ requirements:
 
   run:
     - python
+  run_constrained:
+    - ptable >=9999
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

I have submitted the PyPI package [PTable](https://pypi.org/project/PTable/) to staged-recipes (https://github.com/conda-forge/staged-recipes/pull/7127). It is a fork of prettytable, and thus could interfere with it. This PR prevents PTable and prettytable from being installed in the same environment.