### PR TITLE
Update Python requirements for PrettyTable 3.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "prettytable" %}
-{% set version = "2.5.0" %}
+{% set version = "3.0.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f7da57ba63d55116d65e5acb147bfdfa60dceccabf0d607d6817ee2888a05f2c
+  sha256: 69fe75d78ac8651e16dd61265b9e19626df5d630ae294fc31687aa6037b97a58
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,10 +18,10 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.5
+    - python >=3.7
     - setuptools_scm
   run:
-    - python >=3.5
+    - python >=3.7
     - importlib-metadata
     - wcwidth
   run_constrained:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
To go with https://github.com/conda-forge/prettytable-feedstock/pull/26, PrettyTable 3.0.0 dropped support for Python 3.6:

* https://github.com/jazzband/prettytable/releases/tag/3.0.0

Python 3.5 was dropped in 2.0.0 (Nov 2020):

* https://github.com/jazzband/prettytable/releases/tag/2.0.0
